### PR TITLE
Fix setting multiple cookies in qwik-auth

### DIFF
--- a/packages/qwik-auth/src/index.ts
+++ b/packages/qwik-auth/src/index.ts
@@ -140,17 +140,21 @@ async function authAction(
     ...authOptions,
     skipCSRFCheck,
   });
+  
+  let cookies = [];
   res.headers.forEach((value, key) => {
-    /**
-     * Do not set the header if already set accept in the case of set-cookie which is allowed
-     * https://httpwg.org/specs/rfc6265.html#rfc.section.3
-     */
-    if (!req.headers.has(key) || key === 'set-cookie') {
+    if (key === "set-cookie") {
+      // while browsers would support setting multiple cookies, the fetch implementation does not, so we join them later.
+      cookies.push(value);
+    } else if (!req.headers.has(key)) {
       req.headers.set(key, value);
     }
   });
-  fixCookies(req);
 
+  if (cookies.length > 0) {
+    req.headers.set("set-cookie", cookies.join('; '));
+  }
+  
   try {
     return await res.json();
   } catch (error) {


### PR DESCRIPTION
# Overview

https://github.com/BuilderIO/qwik/pull/5194 introduced functionality to set multiple cookies.
With fetch setting multiple cookies via the set-cookie key is not supported though.
The testing was limited to the PCKE cookie, which passed as that cookie is last in the list coming from auth.js.
Other cookies like next-auth.callback-url would come earlier and would have been discarded by the later cookie.
 

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Instead of setting cookies directly, instead collect them and then create a semicolon seperated string.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
